### PR TITLE
Add subtitle mode (videoplayer-like displaying), fix parsing SRT and refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,14 @@ The rest are completely optional.
    - The style in which subtitles will appear on the screen. (This is set to "Letter" by default. Although can be changed to "Word")
    - "Letter" makes it so that the all characters appear one by one to create a typewriter effect.
    - "Word" makes it so that all words appears one by one instead of characters.
+   - "Subtitles" makes it so that a segment is shown at the start time and hidden on the end time, like in video players.
+  
+7. Container (Node)
+   - Node containing the label
+   - It willbe made visible on start of the segment and hidden on the end of it
+   - Best to use with "subtitles" style
 
-Example:
+Examples:
 ```gdscript
 @onready var animation_player = %AnimationPlayer
 @onready var subtitle : RichTextLabel = %Subtitle
@@ -91,6 +97,35 @@ func _ready():
 		"Style": "word",
 		"Duration": speech_player.stream.get_length()
 	} # Settings which will be passed as an argument.
+	Captions.generate_animation(data)
+	animation_player.play("display_subtitles")
+	if speech_player:
+		speech_player.play()
+
+```
+
+```gdscript
+@onready var animation_player = %AnimationPlayer
+@onready var subtitle : RichTextLabel = %Subtitle
+@onready var external_margin_container = %ExternalMarginContainer
+@export var speech_player : AudioStreamPlayer
+
+func _ready():
+	var data = {
+		"TextPath": r"1
+00:00:01,440 --> 00:00:05,375
+Senator, we're making
+our final approach into Coruscant.
+
+2
+00:00:05,476 --> 00:00:07,501
+Very good, Lieutenant.", 
+		"Label": subtitle,
+		"AnimationPlayer": animation_player, 
+		"Name": "display_subtitles", 
+		"Style": "subtitles",
+		"Container": external_margin_container,
+	}
 	Captions.generate_animation(data)
 	animation_player.play("display_subtitles")
 	if speech_player:

--- a/README.md
+++ b/README.md
@@ -21,12 +21,30 @@ Create a Singleton for this script.
 
 ### Easy Usage
 
-```
+```gdscript
 var data = {"TextPath": "res://path_to_text_file.txt", "Label": label_or_richtextlabel_node} # Settings which will be passed as an argument.
-var animation = Captions.create(data) # Returns an Animation which can be used by AnimationPlayer to start showing the subtitles.
+var animation = Captions.generate_animation(data) # Returns an Animation which can be used by AnimationPlayer to start showing the subtitles.
 ```
 See example below.
-![Screenshot_89](https://github.com/1Othello/godot-speech-to-subtitles/assets/132980114/ef7b88f5-6220-4425-b976-7c8e03c963ba)
+
+```gdscript
+@onready var animation_player = %AnimationPlayer
+@onready var subtitle : RichTextLabel = %Subtitle
+@export var speech_player : AudioStreamPlayer
+
+func _ready():
+	var data = {
+		"TextPath": "res://text_file_format_example.txt", 
+		"Label": subtitle
+	} # Settings which will be passed as an argument.
+	var animation := Captions.generate_animation(data)
+  	animation_player.get_animation_library("").add_animation("display_subtitles", animation)
+	animation_player.play("display_subtitles")
+	if speech_player:
+		speech_player.play()
+
+```
+
 
 ### Moderate Usage
 
@@ -58,15 +76,31 @@ The rest are completely optional.
    - "Letter" makes it so that the all characters appear one by one to create a typewriter effect.
    - "Word" makes it so that all words appears one by one instead of characters.
 
-7. TimeOnly (Bool)
-   - False by default.
-   - Making this True will allow you to instead get an array of all the formatted timestamps.
-   - Example output: [{"text": "The world is mine!", "start": 0.0, "end": 1.0}]
+Example:
+```gdscript
+@onready var animation_player = %AnimationPlayer
+@onready var subtitle : RichTextLabel = %Subtitle
+@export var speech_player : AudioStreamPlayer
 
+func _ready():
+	var data = {
+		"TextPath": "res://text_file_format_example.txt", 
+		"Label": subtitle,
+		"AnimationPlayer": animation_player, 
+		"Name": "display_subtitles", 
+		"Style": "word",
+		"Duration": speech_player.stream.get_length()
+	} # Settings which will be passed as an argument.
+	Captions.generate_animation(data)
+	animation_player.play("display_subtitles")
+	if speech_player:
+		speech_player.play()
+
+```
 
 You can retrieve a template of the dictionary data needed directly from the singleton itself.
 
-```
+```gdscript
 var template = Captions.get_required_template() # Returns a dictionary with only the required keys.
 print(template)
 # Output {"TextPath": "PATH TO .TXT FILE (REQUIRED)", "LABEL": "LABEL OR RICHTEXTLABEL NODE (REQUIRED)"}
@@ -74,7 +108,7 @@ print(template)
 
 Or
 
-```
+```gdscript
 var template = Captions.get_complete_template() # Returns a dictionary with every key.
 print(template)
 # Output {"TextPath": "PATH TO .TXT FILE (REQUIRED)", # Required
@@ -83,8 +117,14 @@ print(template)
 #	"AnimationPlayer": "ANIMATIONPLAYER NODE (OPTIONAL)", # Optional
 #	"Duration": "AUDIO LENGTH (OPTIONAL)", # Optional
 #	"Style": "WORD OR LETTER (OPTIONAL)", # Optional
-#	"TimeOnly": "TRUE OR FALSE (OPTIONAL)" # Optional
 #	}
+```
+
+
+If you want to simply get parsed captions from the file or text input, call `read_and_parse` function:
+```gdscript
+var caption_fields := read_and_parse("res://text_file_format_example.txt")
+
 ```
 
 ## Creating an SRT file (Tutorial)

--- a/captions.gd
+++ b/captions.gd
@@ -1,21 +1,25 @@
 extends Node
 
+func prepare_track(animation : Animation, label : RichTextLabel, update_mode : Animation.UpdateMode) -> int:
+	var track_index := animation.add_track(Animation.TYPE_VALUE)
+	var nodePath = NodePath(label.owner.get_path_to(label))
+	animation.value_track_set_update_mode(track_index, update_mode)
+	animation.track_set_path(track_index, nodePath.get_concatenated_names() + ":text")
+	
+	return track_index
 
 func generate_animation_WORDS(data, caption_fields):
-	var animation = Animation.new()
-	var track_index = animation.add_track(Animation.TYPE_VALUE)
-	var nodePath = NodePath(data["Label"].owner.get_path_to(data["Label"]))
-	animation.value_track_set_update_mode(track_index, Animation.UPDATE_DISCRETE)
-	animation.track_set_path(track_index, nodePath.get_concatenated_names() + ":text")
-	var last_field = caption_fields[caption_fields.size() - 1]
-	caption_fields.remove_at(caption_fields.size() - 1)
-	var written = ""
+	var animation := Animation.new()
+	var track_index := prepare_track(animation, data["Label"], Animation.UPDATE_DISCRETE)
+	var last_field = caption_fields.pop_back()
+	var written := ""
+	var text := ""
 	for caption in caption_fields:
-		var text = caption["text"] # The text being displayed.
+		text = caption["text"] # The text being displayed.
 		var start = caption["start"] # The starting keyframe in seconds.
 		var end = caption["end"] # The ending keyframe in seconds.
 		if text.find(" ") != -1: # Check for whitespaces.
-			var words = text.split(" ") # Get every word.
+			var words := text.split(" ") # Get every word.
 			var midpoint = end - start
 			var WPS = midpoint / words.size()
 			var wordFrequency = WPS
@@ -28,7 +32,7 @@ func generate_animation_WORDS(data, caption_fields):
 			written += text + " "
 			animation.track_insert_key(track_index, end, written)
 
-	var text = last_field["text"]
+	text = last_field["text"]
 	written += " "
 	
 	var duration
@@ -69,22 +73,19 @@ func generate_animation_WORDS(data, caption_fields):
 
 func generate_animation_LETTERS(data, caption_fields):
 	var animation = Animation.new()
-	var track_index = animation.add_track(Animation.TYPE_VALUE)
-	var nodePath = NodePath(data["Label"].owner.get_path_to(data["Label"]))
+	var track_index = prepare_track(animation, data["Label"], Animation.UPDATE_CONTINUOUS)
+	var last_field = caption_fields.pop_back()
 	var full_script = ""
-	animation.value_track_set_update_mode(track_index, Animation.UPDATE_CONTINUOUS)
-	animation.track_set_path(track_index, nodePath.get_concatenated_names() + ":text")
-	var last_field = caption_fields[caption_fields.size() - 1]
-	caption_fields.remove_at(caption_fields.size() - 1)
+	var text := ""
 	for caption in caption_fields:
-		var text = caption["text"] # The text being displayed.
+		text = caption["text"] # The text being displayed.
 		var start = caption["start"] # The starting keyframe in seconds.
 		var end = caption["end"] # The ending keyframe in seconds.
 		animation.track_insert_key(track_index, start, full_script)
 		full_script += text + " "
 		animation.track_insert_key(track_index, end, full_script)
 	
-	var text = last_field["text"]
+	text = last_field["text"]
 
 	animation.track_insert_key(track_index, last_field["start"], full_script)
 	full_script += last_field["text"]

--- a/captions.gd
+++ b/captions.gd
@@ -2,8 +2,7 @@ extends Node
 
 func _prepare_track(animation : Animation, node, update_mode : Animation.UpdateMode, property = "text") -> int:
 	var track_index := animation.add_track(Animation.TYPE_VALUE)
-	var owner = node.owner
-	var nodePath = NodePath(node.owner.get_path_to(node))
+	var nodePath := NodePath(node.owner.get_path_to(node))
 	animation.value_track_set_update_mode(track_index, update_mode)
 	animation.track_set_path(track_index, "%s:%s" % [nodePath.get_concatenated_names(), property])
 	
@@ -25,7 +24,7 @@ func _add_segment_word_by_word_to_track(written : String, caption, animation : A
 		
 	return written
 
-func _generate_animation_WORDS(data : Dictionary, caption_fields):
+func _generate_animation_WORDS(data : Dictionary, caption_fields) -> Animation:
 	var animation := Animation.new()
 	var track_index := _prepare_track(animation, data["Label"], Animation.UPDATE_DISCRETE)
 	var last_field = caption_fields.pop_back()
@@ -40,11 +39,10 @@ func _generate_animation_WORDS(data : Dictionary, caption_fields):
 	
 	if "AnimationPlayer" in data and "Name" in data: # Adds the named animation to the provded animation player.
 		data["AnimationPlayer"].get_animation_library("").add_animation(data["Name"], animation)
-		return true
-	else: # Returns the animation.
-		return animation
 
-func _generate_animation_LETTERS(data, caption_fields):
+	return animation
+
+func _generate_animation_LETTERS(data, caption_fields) -> Animation:
 	var animation := Animation.new()
 	var track_index = _prepare_track(animation, data["Label"], Animation.UPDATE_CONTINUOUS)
 	var last_field = caption_fields.pop_back()
@@ -71,9 +69,8 @@ func _generate_animation_LETTERS(data, caption_fields):
 	
 	if "AnimationPlayer" in data and "Name" in data: # Adds the named animation to the provded animation player.
 		data["AnimationPlayer"].get_animation_library("").add_animation(data["Name"], animation)
-		return true
-	else: # Returns the animation.
-		return animation
+
+	return animation
 
 func _parse_subtitles(content : String) -> Array:
 	var caption_fields := []	
@@ -100,7 +97,7 @@ func read_and_parse(text_path : String) -> Array:
 
 	return caption_fields
 
-func generate_animation(data: Dictionary): # Creates and returns a label animation with the captions provided.
+func generate_animation(data: Dictionary) -> Animation: # Creates and returns a label animation with the captions provided.
 	var caption_fields := read_and_parse(data["TextPath"])
 
 	match data.get("Style", "letters").to_lower():

--- a/captions.gd
+++ b/captions.gd
@@ -1,28 +1,58 @@
 extends Node
 
-func _prepare_track(animation : Animation, node, update_mode : Animation.UpdateMode, property = "text") -> int:
-	var track_index := animation.add_track(Animation.TYPE_VALUE)
-	var nodePath := NodePath(node.owner.get_path_to(node))
-	animation.value_track_set_update_mode(track_index, update_mode)
-	animation.track_set_path(track_index, "%s:%s" % [nodePath.get_concatenated_names(), property])
+func generate_animation(data: Dictionary) -> Animation:
+	var caption_fields := read_and_parse(data["TextPath"])
+
+	match data.get("Style", "letters").to_lower():
+		"word":
+			return _generate_animation_WORDS(data, caption_fields)
+		"subtitles":
+			return _generate_animation_subtitles(data, caption_fields)
+		_:
+			return _generate_animation_LETTERS(data, caption_fields)
+
+func read_and_parse(text_path : String) -> Array:
+	var caption_fields := []
 	
-	return track_index
+	if text_path.is_absolute_path():
+		var raw_file := FileAccess.open(text_path, FileAccess.READ)
+		caption_fields = _parse_subtitles(raw_file.get_as_text())
+		raw_file.close()
+	else:
+		caption_fields = _parse_subtitles(text_path)
 
-func _add_segment_word_by_word_to_track(written : String, caption, animation : Animation, track_index : int, end_override := 0.0) -> String:
-	var text : String = caption["text"]
-	var start : float = caption["start"]
-	var end : float = caption["end"] if not end_override else end_override
-	var words := text.split(" ")
-	var segment_duration := end - start
-	var word_duration := segment_duration / words.size()
+	return caption_fields
 
-	var currentTime := start
-	for word in words:
-		currentTime += word_duration
-		written += word + " "
-		animation.track_insert_key(track_index, currentTime, written)
-		
-	return written
+func get_complete_template() -> Dictionary:
+	var template = {"TextPath": "PATH TO .TXT FILE (REQUIRED)", # Required
+	"Label": "LABEL OR RICHTEXTLABEL NODE (REQUIRED)", # Required
+	"Name": "NEW ANIMATION NAME (OPTIONAL)", # Optional
+	"AnimationPlayer": "ANIMATIONPLAYER NODE (OPTIONAL)", # Optional
+	"Duration": "AUDIO LENGTH (OPTIONAL)", # Optional
+	"Style": "WORD OR LETTER (OPTIONAL)", # Optional
+	"Container": "NODE CONTAINING THE LABEL TO BE ENABLED/DISABLED ON START/END OF EACH SEGMENT (OPTIONAL)" # Optional
+	}
+	return template
+	
+func get_required_template() -> Dictionary:
+	var template = {"TextPath": "PATH TO .TXT FILE (REQUIRED)", "LABEL": "LABEL OR RICHTEXTLABEL NODE (REQUIRED)"}
+	return template
+
+func _parse_subtitles(content : String) -> Array:
+	var caption_fields := []	
+	var content_regex := RegEx.new()
+	content_regex.compile(r'\d+[\r\n]((?<start>\d+:\d+:\d+,\d+) --> (?<end>\d+:\d+:\d+,\d+))[\r\n](?<text>(.+\r?\n)+(?=(\r?\n)?))')
+	for result in content_regex.search_all(content):
+		caption_fields.append({
+			"text": result.get_string("text").strip_edges(), 
+			"start": _timestamp_to_seconds(result.get_string("start")), 
+			"end": _timestamp_to_seconds(result.get_string("end"))
+		})
+	return caption_fields
+
+func _timestamp_to_seconds(timestamp : String) -> float:
+	var segments = timestamp.split(":")
+	return float(segments[0]) * 3600 + float(segments[1]) * 60 + float(segments[2].split(",")[0]) + float(segments[2].split(",")[1]) / 1000.0
 
 func _generate_animation_WORDS(data : Dictionary, caption_fields : Array[Dictionary]) -> Animation:
 	var animation := Animation.new()
@@ -92,56 +122,26 @@ func _generate_animation_subtitles(data : Dictionary, caption_fields) -> Animati
 	
 	return animation
 
-func _parse_subtitles(content : String) -> Array:
-	var caption_fields := []	
-	var content_regex := RegEx.new()
-	content_regex.compile(r'\d+[\r\n]((?<start>\d+:\d+:\d+,\d+) --> (?<end>\d+:\d+:\d+,\d+))[\r\n](?<text>(.+\r?\n)+(?=(\r?\n)?))')
-	for result in content_regex.search_all(content):
-		caption_fields.append({
-			"text": result.get_string("text").strip_edges(), 
-			"start": _timestamp_to_seconds(result.get_string("start")), 
-			"end": _timestamp_to_seconds(result.get_string("end"))
-		})
-	return caption_fields
-
-func read_and_parse(text_path : String) -> Array:
-	var caption_fields := []
+func _prepare_track(animation : Animation, node, update_mode : Animation.UpdateMode, property = "text") -> int:
+	var track_index := animation.add_track(Animation.TYPE_VALUE)
+	var nodePath := NodePath(node.owner.get_path_to(node))
+	animation.value_track_set_update_mode(track_index, update_mode)
+	animation.track_set_path(track_index, "%s:%s" % [nodePath.get_concatenated_names(), property])
 	
-	if text_path.is_absolute_path():
-		var raw_file := FileAccess.open(text_path, FileAccess.READ)
-		caption_fields = _parse_subtitles(raw_file.get_as_text())
-		raw_file.close()
-	else:
-		caption_fields = _parse_subtitles(text_path)
+	return track_index
 
-	return caption_fields
+func _add_segment_word_by_word_to_track(written : String, caption, animation : Animation, track_index : int, end_override := 0.0) -> String:
+	var text : String = caption["text"]
+	var start : float = caption["start"]
+	var end : float = caption["end"] if not end_override else end_override
+	var words := text.split(" ")
+	var segment_duration := end - start
+	var word_duration := segment_duration / words.size()
 
-func generate_animation(data: Dictionary) -> Animation:
-	var caption_fields := read_and_parse(data["TextPath"])
-
-	match data.get("Style", "letters").to_lower():
-		"word":
-			return _generate_animation_WORDS(data, caption_fields)
-		"subtitles":
-			return _generate_animation_subtitles(data, caption_fields)
-		_:
-			return _generate_animation_LETTERS(data, caption_fields)
-
-func _timestamp_to_seconds(timestamp : String) -> float:
-	var segments = timestamp.split(":")
-	return float(segments[0]) * 3600 + float(segments[1]) * 60 + float(segments[2].split(",")[0]) + float(segments[2].split(",")[1]) / 1000.0
-
-func get_complete_template() -> Dictionary:
-	var template = {"TextPath": "PATH TO .TXT FILE (REQUIRED)", # Required
-	"Label": "LABEL OR RICHTEXTLABEL NODE (REQUIRED)", # Required
-	"Name": "NEW ANIMATION NAME (OPTIONAL)", # Optional
-	"AnimationPlayer": "ANIMATIONPLAYER NODE (OPTIONAL)", # Optional
-	"Duration": "AUDIO LENGTH (OPTIONAL)", # Optional
-	"Style": "WORD OR LETTER (OPTIONAL)", # Optional
-	"Container": "NODE CONTAINING THE LABEL TO BE ENABLED/DISABLED ON START/END OF EACH SEGMENT (OPTIONAL)" # Optional
-	}
-	return template
-	
-func get_required_template() -> Dictionary:
-	var template = {"TextPath": "PATH TO .TXT FILE (REQUIRED)", "LABEL": "LABEL OR RICHTEXTLABEL NODE (REQUIRED)"}
-	return template
+	var currentTime := start
+	for word in words:
+		currentTime += word_duration
+		written += word + " "
+		animation.track_insert_key(track_index, currentTime, written)
+		
+	return written

--- a/captions.gd
+++ b/captions.gd
@@ -9,14 +9,14 @@ func _prepare_track(animation : Animation, node, update_mode : Animation.UpdateM
 	return track_index
 
 func _add_segment_word_by_word_to_track(written : String, caption, animation : Animation, track_index : int, end_override := 0.0) -> String:
-	var text := caption["text"] as String # The text being displayed.
-	var start := caption["start"] as float # The starting keyframe in seconds.
-	var end := caption["end"] as float if not end_override else end_override # The ending keyframe in seconds.
-	var words := text.split(" ") # Get every word.
+	var text : String = caption["text"]
+	var start : float = caption["start"]
+	var end : float = caption["end"] if not end_override else end_override
+	var words := text.split(" ")
 	var segment_duration := end - start
-	var word_duration = segment_duration / words.size()
+	var word_duration := segment_duration / words.size()
 
-	var currentTime = start
+	var currentTime := start
 	for word in words:
 		currentTime += word_duration
 		written += word + " "
@@ -24,10 +24,10 @@ func _add_segment_word_by_word_to_track(written : String, caption, animation : A
 		
 	return written
 
-func _generate_animation_WORDS(data : Dictionary, caption_fields) -> Animation:
+func _generate_animation_WORDS(data : Dictionary, caption_fields : Array[Dictionary]) -> Animation:
 	var animation := Animation.new()
 	var track_index := _prepare_track(animation, data["Label"], Animation.UPDATE_DISCRETE)
-	var last_field = caption_fields.pop_back()
+	var last_field : Dictionary = caption_fields.pop_back()
 	var written := ""
 	for caption in caption_fields:
 		written = _add_segment_word_by_word_to_track(written, caption, animation, track_index)
@@ -37,20 +37,21 @@ func _generate_animation_WORDS(data : Dictionary, caption_fields) -> Animation:
 	
 	animation.length = duration
 	
-	if "AnimationPlayer" in data and "Name" in data: # Adds the named animation to the provded animation player.
+	if "AnimationPlayer" in data and "Name" in data:
 		data["AnimationPlayer"].get_animation_library("").add_animation(data["Name"], animation)
 
 	return animation
 
-func _generate_animation_LETTERS(data, caption_fields) -> Animation:
+func _generate_animation_LETTERS(data : Dictionary, caption_fields) -> Animation:
 	var animation := Animation.new()
 	var track_index := _prepare_track(animation, data["Label"], Animation.UPDATE_CONTINUOUS)
 	var full_script := ""
 	var last_key_index : int = -1
 	for caption in caption_fields:
-		var text : String = caption["text"] # The text being displayed.
-		var start : float = caption["start"] # The starting keyframe in seconds.
-		var end : float = caption["end"] # The ending keyframe in seconds.
+		var text : String = caption["text"]
+		var start : float = caption["start"]
+		var end : float = caption["end"]
+
 		animation.track_insert_key(track_index, start, full_script)
 		full_script += text + " "
 		last_key_index = animation.track_insert_key(track_index, end, full_script)
@@ -60,21 +61,21 @@ func _generate_animation_LETTERS(data, caption_fields) -> Animation:
 	
 	animation.length = duration
 	
-	if "AnimationPlayer" in data and "Name" in data: # Adds the named animation to the provded animation player.
+	if "AnimationPlayer" in data and "Name" in data:
 		data["AnimationPlayer"].get_animation_library("").add_animation(data["Name"], animation)
 
 	return animation
 	
 func _generate_animation_subtitles(data : Dictionary, caption_fields) -> Animation:
 	var animation := Animation.new()
-	var track_index = _prepare_track(animation, data["Label"], Animation.UPDATE_DISCRETE)
+	var track_index := _prepare_track(animation, data["Label"], Animation.UPDATE_DISCRETE)
 	var has_container := data.has("Container")
 	var container_track_index := -1 if not has_container else _prepare_track(animation, data["Container"], Animation.UPDATE_DISCRETE, "visible")
 	print((data["AnimationPlayer"] as AnimationPlayer).root_node)
 	for caption in caption_fields:
-		var text = caption["text"]
-		var start = caption["start"]
-		var end = caption["end"]
+		var text : String = caption["text"]
+		var start : float = caption["start"]
+		var end : float = caption["end"]
 		
 		animation.track_insert_key(track_index, start, text)
 		animation.track_insert_key(track_index, end, "")
@@ -115,7 +116,7 @@ func read_and_parse(text_path : String) -> Array:
 
 	return caption_fields
 
-func generate_animation(data: Dictionary) -> Animation: # Creates and returns a label animation with the captions provided.
+func generate_animation(data: Dictionary) -> Animation:
 	var caption_fields := read_and_parse(data["TextPath"])
 
 	match data.get("Style", "letters").to_lower():
@@ -130,7 +131,7 @@ func _timestamp_to_seconds(timestamp : String) -> float:
 	var segments = timestamp.split(":")
 	return float(segments[0]) * 3600 + float(segments[1]) * 60 + float(segments[2].split(",")[0]) + float(segments[2].split(",")[1]) / 1000.0
 
-func get_complete_template():
+func get_complete_template() -> Dictionary:
 	var template = {"TextPath": "PATH TO .TXT FILE (REQUIRED)", # Required
 	"Label": "LABEL OR RICHTEXTLABEL NODE (REQUIRED)", # Required
 	"Name": "NEW ANIMATION NAME (OPTIONAL)", # Optional
@@ -141,6 +142,6 @@ func get_complete_template():
 	}
 	return template
 	
-func get_required_template():
+func get_required_template() -> Dictionary:
 	var template = {"TextPath": "PATH TO .TXT FILE (REQUIRED)", "LABEL": "LABEL OR RICHTEXTLABEL NODE (REQUIRED)"}
 	return template

--- a/captions.gd
+++ b/captions.gd
@@ -44,26 +44,19 @@ func _generate_animation_WORDS(data : Dictionary, caption_fields) -> Animation:
 
 func _generate_animation_LETTERS(data, caption_fields) -> Animation:
 	var animation := Animation.new()
-	var track_index = _prepare_track(animation, data["Label"], Animation.UPDATE_CONTINUOUS)
-	var last_field = caption_fields.pop_back()
-	var full_script = ""
-	var text := ""
+	var track_index := _prepare_track(animation, data["Label"], Animation.UPDATE_CONTINUOUS)
+	var full_script := ""
+	var last_key_index : int = -1
 	for caption in caption_fields:
-		text = caption["text"] # The text being displayed.
-		var start = caption["start"] # The starting keyframe in seconds.
-		var end = caption["end"] # The ending keyframe in seconds.
+		var text : String = caption["text"] # The text being displayed.
+		var start : float = caption["start"] # The starting keyframe in seconds.
+		var end : float = caption["end"] # The ending keyframe in seconds.
 		animation.track_insert_key(track_index, start, full_script)
 		full_script += text + " "
-		animation.track_insert_key(track_index, end, full_script)
+		last_key_index = animation.track_insert_key(track_index, end, full_script)
 	
-	text = last_field["text"]
-
-	animation.track_insert_key(track_index, last_field["start"], full_script)
-	full_script += last_field["text"]
-		
-	var duration : float = data.get("Duration", last_field["end"]) 
-	
-	animation.track_insert_key(track_index, duration, full_script)
+	var duration : float = data.get("Duration", caption_fields.back()["end"])
+	animation.track_set_key_time(track_index, last_key_index, duration)
 	
 	animation.length = duration
 	
@@ -89,8 +82,7 @@ func read_and_parse(text_path : String) -> Array:
 	
 	if text_path.is_absolute_path():
 		var raw_file := FileAccess.open(text_path, FileAccess.READ)
-		var content := raw_file.get_as_text()
-		caption_fields = _parse_subtitles(content)
+		caption_fields = _parse_subtitles(raw_file.get_as_text())
 		raw_file.close()
 	else:
 		caption_fields = _parse_subtitles(text_path)

--- a/captions.gd
+++ b/captions.gd
@@ -85,10 +85,9 @@ func parse_subtitles(content : String) -> Array:
 		})
 	return caption_fields
 
-func create(data: Dictionary): # Creates and returns a label animation with the captions provided.
+func read_and_parse(text_path : String) -> Array:
 	var caption_fields := []
 	
-	var text_path : String = data["TextPath"]
 	if text_path.is_absolute_path():
 		var raw_file := FileAccess.open(text_path, FileAccess.READ)
 		var content := raw_file.get_as_text()
@@ -96,20 +95,21 @@ func create(data: Dictionary): # Creates and returns a label animation with the 
 		raw_file.close()
 	else:
 		caption_fields = parse_subtitles(text_path)
+
+	return caption_fields
+
+func create(data: Dictionary): # Creates and returns a label animation with the captions provided.
+	var caption_fields := read_and_parse(data["TextPath"])
 		
 	if "TimeOnly" in data and data["TimeOnly"]: # Returns caption fields without animating them.
 		return caption_fields
 	
-	if "Style" in data: # The style of the animation.
-		if data["Style"].to_lower() == "word":
-			var outcome = generate_animation_WORDS(data, caption_fields)
-			return outcome
-		else:
-			var outcome = generate_animation_LETTERS(data, caption_fields)
-			return outcome
-	else: # Uses LETTERS as default.
-		var outcome = generate_animation_LETTERS(data, caption_fields)
-		return outcome
+
+	match data.get("Style", "letters").to_lower():
+		"word":
+			return generate_animation_WORDS(data, caption_fields)
+		_:
+			return generate_animation_LETTERS(data, caption_fields)
 
 func timestamp_to_seconds(timestamp : String) -> float:
 	var segments = timestamp.split(":")


### PR DESCRIPTION
I found this repository while looking for subtitles plugin for my accessibility workshop. I liked that you use SRT format, as I was looking for something that could be used in cutscenes. However, I realized that it's not using the data as videoplayers do and instead of creating my own version from scratch I decided do build on top of your project and give my changes back.

It started small, but in the end git diff will not be useful to finding out what the changes are. So, to sum up in few points:
1. Code was refactored - I've seen some redundant parts and started to limit repetitions whenever I knew what to do.
2. Static types were added in most places - it made it easier for me to know if everything was working well, as I had more code completion. 
3. Some issues were fixed - SRT might have multiple lines in each segment and it was not working correctly. Regex used can be tested here - https://regex101.com/r/MCt4cQ/1 It's based on this SO answer - https://stackoverflow.com/a/71585341/1816426
4. "Subtitles" mode was added - that's the only thing I needed and I believe more people might be interested in it.
5. Getting parsed captions/subtitles only was separated - in my opinion it's better than having the `"TimeOnly"` parameter.
6. Return types of functions were unified - some functions were either returning `Animation` or `bool` or `Dictionary`.

Feel free to take whatever you feel fitting. I know it's a lot for a single PR, but I didn't want to create multiple PRs with different changes, as most parts were interconnected due to refactor. You can check separate commits I did to see how it progressed.

There are some parts I would change even more but I have to move on with the workshop and leave reafactoring for now.